### PR TITLE
Solucion a la violacion del OCP

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>turing-machine</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/ConfigurationImpl.java
+++ b/ConfigurationImpl.java
@@ -7,102 +7,87 @@ import java.util.List;
 public class ConfigurationImpl implements Configuration{
 
 
-	public  TuringMachine tm;
-	private HashMap<Integer, Character> tape;
-	private int currentPosition;
-	private String currentState;
+	private Tape tape;
+    private int currentPosition;
+    private String currentState;
+    private TuringMachine tm;
 
-	public ConfigurationImpl(TuringMachine tm) {
-		this.tm  = tm;
-		this.tape = new HashMap<Integer, Character>();
-		this.currentPosition = 0 ;
-		this.currentState = tm.getInitialState();
-	}
+    public ConfigurationImpl(TuringMachine tm, Tape tape) {
+        this.tm = tm;
+        this.tape = tape;
+        this.currentPosition = 0;
+        this.currentState = tm.getInitialState();
+    }
 
-	@Override
-	public int getLeftEnd() {
-		int leftEnd = Integer.MAX_VALUE;
-		for(int item : this.tape.keySet()) {
-			leftEnd = item < leftEnd ? item : leftEnd ;
-		}
-		return leftEnd ;
-	}
+    @Override
+    public int getLeftEnd() {
+        return tape.getLeftEnd();
+    }
 
-	@Override
-	public int getRightEnd() {
-		int rightEnd = Integer.MIN_VALUE;
-		for(int item : this.tape.keySet()) {
-			rightEnd = item < rightEnd ? item : rightEnd ;
-		}
-		return rightEnd ;
-	}
+    @Override
+    public int getRightEnd() {
+        return tape.getRightEnd();
+    }
 
-	@Override
-	public int getCurrentPosition() {
-		return this.currentPosition;
-	}
+    @Override
+    public int getCurrentPosition() {
+        return this.currentPosition;
+    }
 
-	@Override
-	public String getCurrentState() {
-		return this.currentState;
-	}
+    @Override
+    public String getCurrentState() {
+        return this.currentState;
+    }
 
-	@Override
-	public char getTapeCellSymbol(int position) {
-	
-		return this.tape.keySet().contains(position) ? this.tape.get(position) : this.tm.getBlankSymbol();
-	}
+    @Override
+    public char getTapeCellSymbol(int position) {
+        return tape.getSymbol(position);
+    }
 
-	@Override
-	public boolean canAdvance() {
-		boolean canAdvance = false ; 
-		for(int i = 0 ; i < tm.getRuleCount() ; i ++) {
-			canAdvance =  currentState.equals(tm.getRuleState(i)) && tape.get(currentPosition).equals(tm.getRuleSymbol(i));
-			
-		}
-		
-		return canAdvance ;
-	}
+    @Override
+    public boolean canAdvance() {
+        for (int i = 0; i < tm.getRuleCount(); i++) {
+            if (currentState.equals(tm.getRuleState(i)) && tape.getSymbol(currentPosition) == tm.getRuleSymbol(i)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private int getSuitableRuleNum (int currentPosition, String currentState, TuringMachine tm) {
-		int suitableRule = -1 ;
-		for(int i = 0 ; i < tm.getRuleCount() ; i ++) {
-			suitableRule = currentState.equals(tm.getRuleState(i)) && tape.get(currentPosition).equals(tm.getRuleSymbol(i)) ? i : -1 ;
-		}
-		return suitableRule ;
-	}
-	
-	@Override
-	public void advance() {
-		
-		int suitableRuleNum = getSuitableRuleNum(this.currentPosition, this.currentState, this.tm);
-		
-		
-		setCurrentState(this.tm.getRuleNewState(suitableRuleNum));
-		
-		setTapeCell(this.currentPosition, this.tm.getRuleNewSymbol(suitableRuleNum));
-		
-		int positionEffect = tm.getRuleDirection(suitableRuleNum).equals(Direction.RIGHT) ? 1 : -1 ;
-		setPosition(this.currentPosition + positionEffect);
-		
+    @Override
+    public void advance() {
+        if (canAdvance()) {
+            int suitableRuleNum = getSuitableRuleNum(this.currentPosition, this.currentState, this.tm);
+            setCurrentState(this.tm.getRuleNewState(suitableRuleNum));
+            setTapeCell(this.currentPosition, this.tm.getRuleNewSymbol(suitableRuleNum));
+            int positionEffect = tm.getRuleDirection(suitableRuleNum) == Direction.RIGHT ? 1 : -1;
+            setPosition(this.currentPosition + positionEffect);
+        }
+    }
 
-	}
+    private int getSuitableRuleNum(int currentPosition, String currentState, TuringMachine tm) {
+        for (int i = 0; i < tm.getRuleCount(); i++) {
+            if (currentState.equals(tm.getRuleState(i)) && tape.getSymbol(currentPosition) == tm.getRuleSymbol(i)) {
+                return i;
+            }
+        }
+        return -1;
+    }
 
-	@Override
-	public void setTapeCell(int position, char newValue) {
-		this.tape.put(position, newValue);
-	}
+    @Override
+    public void setTapeCell(int position, char newValue) {
+        tape.setSymbol(position, newValue);
+    }
 
-	@Override
-	public void setPosition(int position) {
-		this.currentPosition = position ;
-	}
+    @Override
+    public void setPosition(int position) {
+        this.currentPosition = position;
+    }
 
-	@Override
-	public void setCurrentState(String state) {
-		this.currentState = state ;
-		
-	}
+    @Override
+    public void setCurrentState(String state) {
+        this.currentState = state;
+    }
 
 	@Override
 	public void addConfigurationObserver(ConfigurationObserver o) {

--- a/HashMapTape.java
+++ b/HashMapTape.java
@@ -1,0 +1,30 @@
+
+public class HashMapTape implements Tape {
+	private HashMap<Integer, Character> tape;
+    private char blankSymbol;
+
+    public HashMapTape(char blankSymbol) {
+        this.tape = new HashMap<>();
+        this.blankSymbol = blankSymbol;
+    }
+
+    @Override
+    public char getSymbol(int position) {
+        return tape.getOrDefault(position, blankSymbol);
+    }
+
+    @Override
+    public void setSymbol(int position, char symbol) {
+        tape.put(position, symbol);
+    }
+
+    @Override
+    public int getLeftEnd() {
+        return tape.keySet().stream().min(Integer::compare).orElse(0);
+    }
+
+    @Override
+    public int getRightEnd() {
+        return tape.keySet().stream().max(Integer::compare).orElse(0);
+    }
+}

--- a/Tape.java
+++ b/Tape.java
@@ -1,0 +1,4 @@
+
+public interface Tape {
+
+}


### PR DESCRIPTION
Problema: 
En la clase ConfigurationImpl, la cinta (Tape) se almacena usando un HashMap<Integer, Character>. Si deseáramos cambiar la estructura de datos para almacenar la cinta (Tape), como de HashMap a ArrayList u otra estructura, tendríamos que modificar directamente la clase ConfigurationImpl. Esto viola el principio de Abierto/Cerrado porque implica cambiar el código existente para añadir una nueva funcionalidad, en vez de que esa adición ocurra sin tener que cambiar el código.
Solución:
Para solucionar la violación que ocurre al principio Abierto/Cerrado debemos de crear una interfaz Tape la cual define las operaciones básicas necesarias para interactuar con la cinta. Esta interfaz permite abstraer la implementación de la cinta, haciendo posible cambiar la estructura de datos subyacente sin afectar las clases que dependen de ella. 
Una vez creada esta interfaz podemos desarrollar una clase de estructura de datos como HashMapTape que la implemente. 
Ahora implementaremos en la clase ConfigurationImpl la interfaz Configuration y utilizaremos una instancia de Tape en la misma para manejar la cinta. Esta nueva instancia permite que en esta clase se pueda cambiar la estructura de datos en ConfigurationImpl sin tener que cambiar el codigo interno de la clase, cumpliendo así el principio de Abierto/Cerrado. 